### PR TITLE
Update URLs to Altice Labs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,11 @@ Since the development of Kyoto Tycoon by its original authors seems to have
 halted around 2012, we're also maintaining an updated and ready-to-go fork
 of it here:
 
-   https://github.com/sapo/kyoto
+   https://github.com/alticelabs/kyoto
 
 For more information on Kyoto Tycoon server, please refer to:
 
-   http://sapo.github.io/kyoto/kyototycoon/doc/
+   http://alticelabs.github.io/kyoto/kyototycoon/doc/
 
 
 FEATURES

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     license='BSD',
     keywords='Kyoto Tycoon, Kyoto Cabinet',
     packages=['kyototycoon'],
-    url='https://github.com/sapo/python-kyototycoon',
+    url='https://github.com/alticelabs/python-kyototycoon-ng',
 )


### PR DESCRIPTION
Kyoto-related projects have moved from SAPO to Altice Labs, URLs need to be updated accordingly.
